### PR TITLE
Clarify the download entry for the Windows apps.

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -19,7 +19,7 @@ You have to add wallabag in your toolbar. Then, just click on this icon to walla
 * application for Android ([f-droid](https://f-droid.org/app/fr.gaulupeau.apps.InThePoche) and [google play](https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche)) – developed by Jonathan Gaulupeau.
 This extension adds a wallabag icon in the share menu.  
 *[source code](https://github.com/wallabag/android-app)*
-* application for [Windows (8+)](http://apps.microsoft.com/windows/app/wallabag/f551b9c4-7346-4509-ae46-c6167c705a30) and [Windows Phone](http://www.windowsphone.com/s?appid=d5226cf1-f422-4e00-996c-88e9c5233332) – developed by Julian Oster.
+* application for ~~[Windows (8+)](http://apps.microsoft.com/windows/app/wallabag/f551b9c4-7346-4509-ae46-c6167c705a30)~~ (currently not available) and [Windows Phone](http://www.windowsphone.com/s?appid=d5226cf1-f422-4e00-996c-88e9c5233332) – developed by Julian Oster.
 *[source code](https://github.com/wallabag/windows-app)*
 * [application for iOS](https://itunes.apple.com/app/wallabag/id828331015?mt=8) – developed by Kevin Meyer.  
 *[source code](https://github.com/wallabag/ios-app)*

--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -19,8 +19,7 @@ You have to add wallabag in your toolbar. Then, just click on this icon to walla
 * application for Android ([f-droid](https://f-droid.org/app/fr.gaulupeau.apps.InThePoche) and [google play](https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche)) – developed by Jonathan Gaulupeau.
 This extension adds a wallabag icon in the share menu.  
 *[source code](https://github.com/wallabag/android-app)*
-* [application for Windows Phone](http://www.windowsphone.com/en-US/store/app/wallabag/d5226cf1-f422-4e00-996c-88e9c5233332) – developed by Julian Oster.
-This extension adds a wallabag icon in the share menu.
+* application for [Windows (8+)](http://apps.microsoft.com/windows/app/wallabag/f551b9c4-7346-4509-ae46-c6167c705a30) and [Windows Phone](http://www.windowsphone.com/s?appid=d5226cf1-f422-4e00-996c-88e9c5233332) – developed by Julian Oster.
 *[source code](https://github.com/wallabag/windows-app)*
 * [application for iOS](https://itunes.apple.com/app/wallabag/id828331015?mt=8) – developed by Kevin Meyer.  
 *[source code](https://github.com/wallabag/ios-app)*


### PR DESCRIPTION
As mentioned in #4 the download links are now (hopefully) more clear.
This PR doesn't change the sidebar right now, since there are two apps.

If it's okay for either @nicosomb or @tcitworld I would add a new entry to the sidebar for the desktop app later.