### PR TITLE
Add application name to title

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 AUTHOR = u'Nicolas L\u0153uillet'
-SITENAME = u'a self hostable application for saving web pages'
+SITENAME = u'wallabag: a self hostable application for saving web pages'
 
 PATH = 'content'
 


### PR DESCRIPTION
The title of the RSS feed is just "a self hostable application for saving web pages" and it's missing the name of the application itself. Not a big deal but I think the name of the software should be in the feed title by default. I'm not familiar with Pelican though so I'm not sure if this change will affect the title of the RSS feed. Let me know if I need to change something else instead.